### PR TITLE
Store values as serailized terms

### DIFF
--- a/src/cream.erl
+++ b/src/cream.erl
@@ -58,7 +58,8 @@ cache(Cache, Key, ExpensiveValFun) ->
             binary_to_term(CachedValBin);
         notfound ->
             Val = ExpensiveValFun(),
-            ok = cream_nif:insert(Cache, KeyBin, Val),
+            ValBin = term_to_binary(Val),
+            ok = cream_nif:insert(Cache, KeyBin, ValBin),
             Val
     end.
 

--- a/src/cream.erl
+++ b/src/cream.erl
@@ -131,25 +131,25 @@ drain(Cache) ->
 basic_all_feature__test() ->
     {ok, Cache} = cream:new(3),
 
-    ok = cream:insert(Cache, 1, 1),
+    1 = cream:cache(Cache, 1, fun() -> 1 end),
     ?assertEqual(true, cream:contains(Cache, 1)),
     ?assertEqual(false, cream:contains(Cache, <<2>>)),
     ?assertEqual(false, cream:contains(Cache, three)),
     ?assertEqual(false, cream:contains(Cache, "four")),
 
-    ok = cream:insert(Cache, <<2>>, two),
+    two = cream:cache(Cache, <<2>>, fun() -> two end),
     ?assertEqual(true, cream:contains(Cache, 1)),
     ?assertEqual(true, cream:contains(Cache, <<2>>)),
     ?assertEqual(false, cream:contains(Cache, three)),
     ?assertEqual(false, cream:contains(Cache, "four")),
 
-    ok = cream:insert(Cache, three, "three"),
+    "three" = cream:cache(Cache, three, fun() -> "three" end),
     ?assertEqual(true, cream:contains(Cache, 1)),
     ?assertEqual(true, cream:contains(Cache, <<2>>)),
     ?assertEqual(true, cream:contains(Cache, three)),
     ?assertEqual(false, cream:contains(Cache, "four")),
 
-    ok = cream:insert(Cache, "four", <<"four">>),
+    <<"four">> = cream:cache(Cache, "four", fun() -> <<"four">> end),
     ?assertEqual(true, cream:contains(Cache, <<2>>)),
     ?assertEqual(true, cream:contains(Cache, three)),
     ?assertEqual(true, cream:contains(Cache, "four")),

--- a/src/cream.erl
+++ b/src/cream.erl
@@ -54,8 +54,8 @@ new(MaxCapacity, CacheOpts) ->
 cache(Cache, Key, ExpensiveValFun) ->
     KeyBin = term_to_binary(Key),
     case cream_nif:get(Cache, KeyBin) of
-        {ok, CachedVal} ->
-            CachedVal;
+        {ok, CachedValBin} ->
+            binary_to_term(CachedValBin);
         notfound ->
             Val = ExpensiveValFun(),
             ok = cream_nif:insert(Cache, KeyBin, Val),
@@ -73,7 +73,8 @@ cache(Cache, Key, ExpensiveValFun) ->
 ) -> ok.
 insert(Cache, Key, Value) ->
     KeyBin = term_to_binary(Key),
-    cream_nif:insert(Cache, KeyBin, Value).
+    ValueBin = term_to_binary(Value),
+    cream_nif:insert(Cache, KeyBin, ValueBin).
 
 -spec contains(
     Cache :: reference(),
@@ -89,7 +90,10 @@ contains(Cache, Key) ->
 ) -> notfound | {ok, term()}.
 get(Cache, Key) ->
     KeyBin = term_to_binary(Key),
-    cream_nif:get(Cache, KeyBin).
+    case cream_nif:get(Cache, KeyBin) of
+        {ok, ValueBin} -> {ok, binary_to_term(ValueBin)};
+        Other -> Other
+    end.
 
 -spec evict(
     Cache :: reference(),

--- a/src/cream_nif.erl
+++ b/src/cream_nif.erl
@@ -25,7 +25,7 @@ new(_MaxCapacity, _CacheOpts) ->
 -spec insert(
     Cache :: reference(),
     Key :: binary(),
-    Value :: term()
+    Value :: binary()
 ) -> ok.
 insert(_Cache, _Key, _Value) ->
     ?NOT_LOADED.
@@ -40,7 +40,7 @@ contains(_Cache, _Key) ->
 -spec get(
     Cache :: reference(),
     Key :: binary()
-) -> notfound | {ok, term()}.
+) -> notfound | {ok, binary()}.
 get(_Cache, _Key) ->
     ?NOT_LOADED.
 


### PR DESCRIPTION
I initially decided to store values as `TermBox`s, knowing full well that constructing a term box is [known](https://github.com/rusterlium/rustler/issues/382) to be slow and possibly slower than than round-trip Term [de]serialization. However, I haven't benchmarked yet.